### PR TITLE
Updated Ottoman OOBs

### DIFF
--- a/mod/thegreatwar/history/units/TUR_1910.txt
+++ b/mod/thegreatwar/history/units/TUR_1910.txt
@@ -2,29 +2,37 @@
 ###################################################################
 
 division_template = {
-	name = "Infantry Division"
+	name = "Piyade Tümeni" #Infantry Division
 	regiments = {
 		infantry = { x = 0 y = 0 }
 		infantry = { x = 0 y = 1 }
+		infantry = { x = 0 y = 2 }
 		infantry = { x = 1 y = 0 }
 		infantry = { x = 1 y = 1 }
+		infantry = { x = 1 y = 2 }
+		infantry = { x = 2 y = 0 }
+		infantry = { x = 2 y = 1 }
+		infantry = { x = 2 y = 2 }
+		artillery_brigade = { x = 0 y = 3 }
 	}
 	support = {
 		engineer = { x = 0 y = 0 }
+		recon = { x = 0 y = 1 }
 	}
 }
 
 division_template = {
-	name = "Gendarmerie"
+	name = "Jandarma Alayı" #Gendarmerie Regiment
 	regiments = {
 		infantry = { x = 0 y = 0 }
-		infantry = { x = 1 y = 0 }
+		infantry = { x = 0 y = 1 }
+		infantry = { x = 0 y = 2 }
 	}
 	priority = 0
 }
 
 division_template = {
-	name = "Cavalry Division"
+	name = "Süvari Tugayı" #Cavalry Brigade
 	regiments = {
 		cavalry = { x = 0 y = 0 }
 		cavalry = { x = 0 y = 1 }
@@ -37,355 +45,419 @@ division_template = {
 }
 
 ###################################################################
-
+# 7 Corps x 3 divisions + 5 divisions @10,300/division of infantry = 267800, goal of ~270,000 active in 1909
+# 13 cavaly brigades @ 4300/brigade of cavalry = 55900, goal of 55/56K historically
 units = {
 	division = {
 	    name = "1. Piyade Tümeni 'Harbiye'"
 	    location = 9833# Istanbul
-	    division_template = "Gendarmerie"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "2. Piyade Tümeni 'Selimiye'"
 	    location = 9833# Istanbul
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "3. Piyade Tümeni 'Pangalti'"
 	    location = 9833# Istanbul
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
+	    name = "13. Süvari Tugayı"
+	    location = 4112# Istanbul
+	    division_template = "Süvari Tugayı"
+	    start_experience_factor = 0
+	}
+	
+	division = {
 	    name = "Istanbul Garnizon"
 	    location = 9833# Istanbul
-	    division_template = "Gendarmerie"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "4. Piyade Tümeni 'Tekirdag'"
 	    location = 3879# Tekirdag
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "5. Piyade Tümeni 'Gelibolu'"
 	    location = 849# Gelibolu
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "6. Piyade Tümeni 'Smyrna'"
 	    location = 4112# Smyrna
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
+	    name = "12. Süvari Tugayı"
+	    location = 4112# Smyrna
+	    division_template = "Süvari Tugayı"
+	    start_experience_factor = 0
+	}
+	
+	division = {
 	    name = "Çanakkale Garnizon"
 	    location = 6864# Canakkale
-	    division_template = "Gendarmerie"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "7. Piyade Tümeni 'Kirk Kilise'"
 	    location = 922# Kirklareli
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "8. Piyade Tümeni 'Çorlu'"
 	    location = 6895# Corlu
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
-	division = {
-	    name = "9. Piyade Tümeni"
-	    location = 6895# Corlu
-	    division_template = "Infantry Division"
-	    start_experience_factor = 0
-	}
+	#division = {
+	#    name = "9. Piyade Tümeni"
+	#    location = 6895# Corlu
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "3. Tüfek Alayi"
 	    location = 922# Kirklareli
-	    division_template = "Infantry Division"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "10. Piyade Tümeni"
 	    location = 3893# Edirne
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "11. Piyade Tümeni"
 	    location = 9930# Thasos
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
-	division = {
-	    name = "12. Piyade Tümeni"
-	    location = 9930# Thasos
-	    division_template = "Infantry Division"
-	    start_experience_factor = 0
-	}
+	#division = {
+	#    name = "12. Piyade Tümeni"
+	#    location = 9930# Thasos
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "4. Tüfek Alayi"
 	    location = 3893# Edirne
-	    division_template = "Infantry Division"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "Edirne Garnizon"
 	    location = 3893# Edirne
-	    division_template = "Gendarmerie"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "13. Piyade Tümeni 'Selanik'"
 	    location = 11818# Salonica
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
-	    name = "14. Piyade Tümeni"
-	    location = 3526# Serres
-	    division_template = "Infantry Division"
+	    name = "11. Süvari Tugayı"
+	    location = 11818# Salonica
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
+	
+	#division = {
+	#    name = "14. Piyade Tümeni"
+	#    location = 3526# Serres
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "15. Piyade Tümeni"
 	    location = 3526# Kilkis
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
-	division = {
-	    name = "16. Piyade Tümeni"
-	    location = 936# Bitola
-	    division_template = "Infantry Division"
-	    start_experience_factor = 0
-	}
+	#division = {
+	#    name = "16. Piyade Tümeni"
+	#    location = 936# Bitola
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "17. Piyade Tümeni"
 	    location = 9780# Shkoder
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
+	#division = {
+	#    name = "18. Piyade Tümeni"
+	#    location = 9914# Tirane
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
+
 	division = {
-	    name = "18. Piyade Tümeni"
+	    name = "10. Süvari Tugayı"
 	    location = 9914# Tirane
-	    division_template = "Infantry Division"
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
-
-	division = {
-	    name = "6. Tüfek Alayi"
-	    location = 936# Bitola
-	    division_template = "Infantry Division"
-	    start_experience_factor = 0
-	}
+	
+	#division = {
+	#    name = "6. Tüfek Alayi"
+	#    location = 936# Bitola
+	#    division_template = "Jandarma Alayı"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "19. Piyade Tümeni"
 	    location = 3882# Skopje
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
-	division = {
-	    name = "20. Piyade Tümeni"
-	    location = 9780# Shkoder
-	    division_template = "Infantry Division"
-	    start_experience_factor = 0
-	}
+	#division = {
+	#    name = "20. Piyade Tümeni"
+	#    location = 9780# Shkoder
+	#   division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "21. Piyade Tümeni"
 	    location = 966# Kozani
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "7. Tüfek Alayi"
 	    location = 3882# Skopje
-	    division_template = "Infantry Division"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
-	    name = "25. Piyade Tümeni"
-	    location = 792# Beirut
-	    division_template = "Infantry Division"
+	    name = "9. Süvari Tugayı"
+	    location = 3882# Skopje
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
+	
+	#division = {
+	#    name = "25. Piyade Tümeni"
+	#    location = 792# Beirut
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "26. Piyade Tümeni"
 	    location = 12473# Aleppo
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "27. Piyade Tümeni"
 	    location = 1086# Jerusalem
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
+	    name = "8. Süvari Tugayı"
+	    location = 1086# Jerusalem
+	    division_template = "Süvari Tugayı"
+	    start_experience_factor = 0
+	}
+	
+	division = {
 	    name = "8. Tüfek Alayi"
 	    location = 4111# Damascus
-	    division_template = "Infantry Division"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "28. Piyade Tümeni 'Erzurum'"
 	    location = 876# Erzurum
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "29. Piyade Tümeni 'Bayburt'"
 	    location = 9886# Bayburt
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "9. Tüfek Alayi"
 	    location = 876# Erzurum
-	    division_template = "Infantry Division"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
-	division = {
-	    name = "30. Piyade Tümeni"
-	    location = 6919# Erzincan
-	    division_template = "Infantry Division"
-	    start_experience_factor = 0
-	}
+	#division = {
+	#    name = "30. Piyade Tümeni"
+	#    location = 6919# Erzincan
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
-	division = {
-	    name = "31. Piyade Tümeni"
-	    location = 6919# Erzincan
-	    division_template = "Infantry Division"
-	    start_experience_factor = 0
-	}
+	#division = {
+	#    name = "31. Piyade Tümeni"
+	#    location = 6919# Erzincan
+	#    division_template = "Piyade Tümeni"
+	#    start_experience_factor = 0
+	#}
 
 	division = {
 	    name = "32. Piyade Tümeni"
 	    location = 9932# Trabzon
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
+	
+	division = {
+	    name = "7. Süvari Tugayı"
+	    location = 9932# Trabzon
+	    division_template = "Süvari Tugayı"
+	    start_experience_factor = 0
+	}
+	
 	division = {
 	    name = "33. Piyade Tümeni 'Van'"
 	    location = 1463# Van
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "34. Piyade Tümeni 'Mus'"
 	    location = 11880# Mus
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
-	    name = "1. Asiret Süvari Tümeni"
+	    name = "1. Süvari Tugayı"
 	    location = 876# Erzurum
-	    division_template = "Cavalry Division"
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
-	    name = "2. Asiret Süvari Tümeni"
+	    name = "2. Süvari Tugayı"
 	    location = 12376# Agri
-	    division_template = "Cavalry Division"
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
-	    name = "3. Asiret Süvari Tümeni"
+	    name = "3. Süvari Tugayı"
 	    location = 11829# Karakurt
-	    division_template = "Cavalry Division"
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
-	    name = "4. Asiret Süvari Tümeni"
+	    name = "4. Süvari Tugayı"
 	    location = 12416# Derik
-	    division_template = "Cavalry Division"
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "35. Piyade Tümeni 'Musul'"
 	    location = 10106# Mosul
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "36. Piyade Tümeni 'Kerkük'"
 	    location = 10811# Kirkuk
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "37. Piyade Tümeni 'Bagdat'"
 	    location = 2097# Baghdad
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "38. Piyade Tümeni 'Basra'"
 	    location = 2089# Al Basrah
-	    division_template = "Infantry Division"
+	    division_template = "Piyade Tümeni"
 	    start_experience_factor = 0
 	}
 
 	division = {
 	    name = "1. Milis Tümeni 'Bingazi'"
 	    location = 11954# Bengasi
-	    division_template = "Gendarmerie"
+	    division_template = "Jandarma Alayı"
 	    start_experience_factor = 0
 	}
 
 	division = {
+	    name = "5. Süvari Tugayı"
+	    location = 11954 #Bengasi
+	    division_template = "Süvari Tugayı"
+	    start_experience_factor = 0
+	}
+	
+	division = {
 	    name = "2. Milis Tümeni 'Trablus'"
 	    location = 1149# Tripoli
-	    division_template = "Gendarmerie"
+	    division_template = "Jandarma Alayı"
+	    start_experience_factor = 0
+	}
+	division = {
+	    name = "6. Süvari Tugayı"
+	    location = 1149 #Tripoli
+	    division_template = "Süvari Tugayı"
 	    start_experience_factor = 0
 	}
 	navy = {

--- a/mod/thegreatwar/history/units/TUR_1914.txt
+++ b/mod/thegreatwar/history/units/TUR_1914.txt
@@ -2,29 +2,37 @@
 ###################################################################
 
 division_template = {
-	name = "Infantry Division"
+	name = "Piyade Tümeni" #Infantry Division
 	regiments = {
 		infantry = { x = 0 y = 0 }
 		infantry = { x = 0 y = 1 }
+		infantry = { x = 0 y = 2 }
 		infantry = { x = 1 y = 0 }
 		infantry = { x = 1 y = 1 }
+		infantry = { x = 1 y = 2 }
+		infantry = { x = 2 y = 0 }
+		infantry = { x = 2 y = 1 }
+		infantry = { x = 2 y = 2 }
+		artillery_brigade = { x = 0 y = 3 }
 	}
 	support = {
 		engineer = { x = 0 y = 0 }
+		recon = { x = 0 y = 1 }
 	}
 }
 
 division_template = {
-	name = "Gendarmerie"
+	name = "Jandarma Alayı" #Gendarmerie Regiment
 	regiments = {
 		infantry = { x = 0 y = 0 }
-		infantry = { x = 1 y = 0 }
+		infantry = { x = 0 y = 1 }
+		infantry = { x = 0 y = 2 }
 	}
 	priority = 0
 }
 
 division_template = {
-	name = "Cavalry Division"
+	name = "Süvari Tugayı" #Cavalry Brigade
 	regiments = {
 		cavalry = { x = 0 y = 0 }
 		cavalry = { x = 0 y = 1 }
@@ -37,12 +45,17 @@ division_template = {
 }
 
 ###################################################################
-
+# 1914 Pre-war Ottoman OOB from Wikipedia
+# 1st Army @ Istanbul: 15 Divisions of infantry
+# 2nd Army @ Aleppo: 5 Divisions of infantry
+# 3rd Army @ Trabizond: 9 Divisions of infantry, 5 independent infantry regiments, 4 cavalry regiments
+# 4th Army @ Baghdad: 4 Divisions of infantry
+# Placed in game: 33 Infantry Divisions, 5 Gendarmerie Regiments (, 4 Cavalry Brigades
 units = {
 	division= { 
 			name = "1. Piyade Tümeni 'Harbiye'"
 			location=9833 # Istanbul
-			division_template="Gendarmerie"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.1
 			}
 	
@@ -50,7 +63,7 @@ units = {
 	division= { 
 			name = "2. Piyade Tümeni 'Selimiye'"
 			location=9833 # Istanbul
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -58,7 +71,7 @@ units = {
 	division= { 
 			name = "3. Piyade Tümeni 'Pangalti'"
 			location=9833 # Istanbul
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -66,7 +79,7 @@ units = {
 	division= { 
 			name = "Istanbul Garnizon"
 			location=9833 # Istanbul
-			division_template="Gendarmerie"
+			division_template="Jandarma Alayı"
 			start_experience_factor=0
 			}
 	
@@ -74,7 +87,7 @@ units = {
 	division= { 
 			name = "4. Piyade Tümeni 'Kirk Kilise'"
 			location = 922 # Kirklareli
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -82,23 +95,23 @@ units = {
 	division= { 
 			name = "5. Piyade Tümeni 'Çorlu'"
 			location = 6895 # Corlu
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.1
 			}
 	
 	
-	division= { 
-			name = "6. Piyade Tümeni"
-			location = 3893 # Edirne
-			division_template="Infantry Division"
-			start_experience_factor=0.05
-			}
+	#division= { 
+	#		name = "6. Piyade Tümeni"
+	#		location = 3893 # Edirne
+	#		division_template="Piyade Tümeni"
+	#		start_experience_factor=0.05
+	#		}
 	
 	
 	division= { 
 			name = "7. Piyade Tümeni 'Tekirdag'"
 			location = 3879 # Tekirdag
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -106,7 +119,7 @@ units = {
 	division= { 
 			name = "8. Piyade Tümeni"
 			location = 849 # Gelibolu
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -114,7 +127,7 @@ units = {
 	division= { 
 			name = "9. Piyade Tümeni 'Gelibolu'"
 			location = 849 # Gelibolu
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -122,23 +135,23 @@ units = {
 	division= { 
 			name = "Çanakkale Garnizon"
 			location = 6864 # Canakkale
-			division_template="Gendarmerie"
+			division_template="Jandarma Alayı"
 			start_experience_factor=0.05
 			}
 	
 	
-	division= { 
-			name = "10. Piyade Tümeni"
-			location=9833 # Istanbul
-			division_template="Infantry Division"
-			start_experience_factor=0.05
-			}
+	#division= { 
+	#		name = "10. Piyade Tümeni"
+	#		location=9833 # Istanbul
+	#		division_template="Piyade Tümeni"
+	#		start_experience_factor=0.05
+	#		}
 	
 	
 	division= { 
 			name = "11. Piyade Tümeni"
 			location=9833 # Istanbul
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -146,7 +159,7 @@ units = {
 	division= { 
 			name = "12. Piyade Tümeni"
 			location=9833 # Istanbul
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -154,23 +167,23 @@ units = {
 	division= { 
 			name = "19. Piyade Tümeni"
 			location = 3879 # Tekirdag
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.1
 			}
 	
 	
-	division= { 
-			name = "20. Piyade Tümeni"
-			location=9833 # Istanbul
-			division_template="Infantry Division"
-			start_experience_factor=0.05
-			}
+	#division= { 
+	#		name = "20. Piyade Tümeni"
+	#		location=9833 # Istanbul
+	#		division_template="Piyade Tümeni"
+	#		start_experience_factor=0.05
+	#		}
 	
 	
 	division= { 
 			name = "13. Piyade Tümeni"
 			location = 4112 # Smyrna
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -178,7 +191,7 @@ units = {
 	division= { 
 			name = "14. Piyade Tümeni"
 			location = 1005 # Antalya
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -186,7 +199,7 @@ units = {
 	division= { 
 			name = "15. Piyade Tümeni"
 			location = 1122 # Alanya
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -194,23 +207,23 @@ units = {
 	division= { 
 			name = "16. Piyade Tümeni"
 			location=9833 # Istanbul
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
 	
-	division= { 
-			name = "24. Piyade Tümeni"
-			location=9833 # Istanbul
-			division_template="Infantry Division"
-			start_experience_factor=0.05
-			}
+	#division= { 
+	#		name = "24. Piyade Tümeni"
+	#		location=9833 # Istanbul
+	#		division_template="Piyade Tümeni"
+	#		start_experience_factor=0.05
+	#		}
 	
 	
 	division= { 
 			name = "26. Piyade Tümeni"
 			location=9833 # Istanbul
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0
 			}
 	
@@ -218,7 +231,7 @@ units = {
 	division= { 
 			name = "21. Piyade Tümeni"
 			location = 856 # Eskisehir
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0
 			}
 	
@@ -226,7 +239,7 @@ units = {
 	division= { 
 			name = "Samsun Garnizon"
 			location = 6995 # Samsun
-			division_template="Gendarmerie"
+			division_template="Jandarma Alayı"
 			start_experience_factor=0
 			}
 	
@@ -234,7 +247,7 @@ units = {
 	division= { 
 			name = "17. Piyade Tümeni"
 			location = 876 # Erzurum
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -242,7 +255,7 @@ units = {
 	division= { 
 			name = "28. Piyade Tümeni"
 			location = 876 # Erzurum
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -250,7 +263,7 @@ units = {
 	division= { 
 			name = "29. Piyade Tümeni"
 			location = 9886 # Bayburt
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -258,7 +271,7 @@ units = {
 	division= { 
 			name = "Trabzon Garnizon"
 			location=9932 # Trabzon
-			division_template="Gendarmerie"
+			division_template="Jandarma Alayı"
 			start_experience_factor=0
 			}
 	
@@ -266,7 +279,7 @@ units = {
 	division= { 
 			name = "30. Piyade Tümeni"
 			location = 876 # Erzurum
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -274,7 +287,7 @@ units = {
 	division= { 
 			name = "31. Piyade Tümeni"
 			location = 876 # Erzurum
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -282,7 +295,7 @@ units = {
 	division= { 
 			name = "32. Piyade Tümeni"
 			location = 876 # Erzurum
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0
 			}
 	
@@ -290,7 +303,7 @@ units = {
 	division= { 
 			name = "18. Piyade Tümeni"
 			location = 1463 # Van
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -298,7 +311,7 @@ units = {
 	division= { 
 			name = "33. Piyade Tümeni 'Van'"
 			location = 1463 # Van
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -306,31 +319,41 @@ units = {
 	division= { 
 			name = "34. Piyade Tümeni 'Mus'"
 			location = 11880 # Mus
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0
 			}
 	
 	
 	division= { 
-			name = "1. Asiret Süvari Tümeni"
+			name = "1. Süvari Tugayı"
 			location = 876 # Erzurum
-			division_template="Cavalry Division"
+			division_template="Süvari Tugayı"
 			start_experience_factor=0.1
 			}
-	
+	division= { 
+			name = "3. Süvari Tugayı"
+			location = 876 # Erzurum
+			division_template="Süvari Tugayı"
+			start_experience_factor=0.1
+			}
 	
 	division= { 
-			name = "2. Asiret Süvari Tümeni"
+			name = "2. Süvari Tugayı"
 			location = 12376 # Agri
-			division_template="Cavalry Division"
+			division_template="Süvari Tugayı"
 			start_experience_factor=0.1
 			}
-	
+	division= { 
+			name = "4. Süvari Tugayı"
+			location = 12376 # Agri
+			division_template="Süvari Tugayı"
+			start_experience_factor=0.1
+			}
 	
 	division= { 
 			name = "23. Piyade Tümeni"
 			location=12473 # Aleppo
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -338,7 +361,7 @@ units = {
 	division= { 
 			name = "25. Piyade Tümeni"
 			location = 4088 # Gaza
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -346,7 +369,7 @@ units = {
 	division= { 
 			name = "27. Piyade Tümeni"
 			location=792 # Beirut
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0
 			}
 	
@@ -354,7 +377,7 @@ units = {
 	division= { 
 			name = "Kudüs Garnizon"
 			location=1086 # Jerusalem
-			division_template="Gendarmerie"
+			division_template="Jandarma Alayı"
 			start_experience_factor=0
 			# start_equipment_factor = 0.3 
 			# start_manpower_factor = 0.3
@@ -364,7 +387,7 @@ units = {
 	division= { 
 			name = "35. Piyade Tümeni 'Musul'"
 			location=10106 # Mosul
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -372,7 +395,7 @@ units = {
 	division= { 
 			name = "36. Piyade Tümeni 'Bagdat'"
 			location=2097 # Baghdad
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -380,7 +403,7 @@ units = {
 	division= { 
 			name = "37. Piyade Tümeni 'Basra'"
 			location = 2089 # Al Basrah
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	
@@ -388,7 +411,7 @@ units = {
 	division= { 
 			name = "39. Piyade Tümeni"
 			location = 1973 # Ta'izz
-			division_template="Infantry Division"
+			division_template="Piyade Tümeni"
 			start_experience_factor=0.05
 			}
 	 navy = {


### PR DESCRIPTION
Updated Ottoman OOBs with information from Wikipedia, including divisional makeup and corresponding troop strengths. Ottoman OOB should now have similar strength to history, and is significantly stronger.